### PR TITLE
Use FGenericPlatformTime class

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,14 @@ Currently, following sensor models are supported:
     - Laser return mode : only *'Strongest'* is available
 
 
-# System Requirements
+# Tested Environments
 |Element|Requirement|
 |:------:|---|
 |**OS**|Ubuntu 22.04|
-|**CPU**|Intel Core i9, X-series or higher |
-||AMD Ryzen 9, Threadripper or higher|
-|**Cores**|16 or higher|
-|**RAM**|32GB or higher|
-|**GPU**|RTX 3070 or higher|
-|**UE5**|v5.1.x|
+|**CPU**|Intel Core i9-12900K|
+|**RAM**|64GB|
+|**GPU**|RTX 3070Ti|
+|**UE5**|v5.1.x, v5.2.0, v5.2.1|
 
 # Quickstart Guide
 The MetaLidar plugin should be installed in the 'Plugins' folder inside your Unreal Engine 5 project. Also, you should install the [**UDP-Unreal**](https://github.com/getnamo/UDP-Unreal/releases/tag/v2.1.0) plugin, which is a convenience *ActorComponent* UDP wrapper for Unreal Engine. After launching the Unreal Editor, make sure that both plugins are enabled.

--- a/Source/MetaLidar/Private/Velodyne/VelodyneLidarActor.cpp
+++ b/Source/MetaLidar/Private/Velodyne/VelodyneLidarActor.cpp
@@ -70,7 +70,6 @@ void AVelodyneLidarActor::EndPlay(EEndPlayReason::Type Reason)
 // This would be a verrrrry large hitch if done on game thread!
 void AVelodyneLidarActor::LidarThreadTick()
 {
-  int64 Begin      = 0;
   float TimeDiffMs = 0;
 
   //! Make sure to come all the way out of all function routines with this same check

--- a/Source/MetaLidar/Public/LidarBaseActor.h
+++ b/Source/MetaLidar/Public/LidarBaseActor.h
@@ -4,10 +4,10 @@
 
 #include "CoreMinimal.h"
 #include "GameFramework/Actor.h"
+#include "GenericPlatform/GenericPlatformTime.h"
 #include "LidarThreadProcess.h"
 THIRD_PARTY_INCLUDES_START
 #include <UDPComponent.h>
-#include <Velodyne/VelodyneBaseComponent.h>
 THIRD_PARTY_INCLUDES_END
 #include "LidarBaseActor.generated.h"
 
@@ -32,9 +32,8 @@ protected:
   // Called when the game end
   virtual void EndPlay(EEndPlayReason::Type Reason) override;
 
-  uint32 PacketTimestamp;
-  std::chrono::steady_clock::time_point BeginTimestamp;
-  std::chrono::steady_clock::time_point EndTimestamp;
+  uint32 PacketTimestamp  = 0;
+  double BeginTimestamp   = 0.0;
 
 public:
   /**

--- a/Source/MetaLidar/Public/Velodyne/VelodyneLidarActor.h
+++ b/Source/MetaLidar/Public/Velodyne/VelodyneLidarActor.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "Velodyne/VelodyneBaseComponent.h"
 #include "LidarBaseActor.h"
 #include "VelodyneLidarActor.generated.h"
 


### PR DESCRIPTION
Fix to use Unreal Engine's generic time class(FGenericPlatformTime) instead of std::chrono 